### PR TITLE
Added support for legacy options in the module

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -10,7 +10,7 @@
   The module is written as 2 main components one is is installing the package,
   configuring the service etc.., with base install and the second is configuring 
   it as client/server based on the configuration data provided. The configuration 
-  class is broken down into 7 classes
+  class is broken down into 8 classes
 
   ```
   * rsyslog::config::modules
@@ -20,6 +20,7 @@
   * rsyslog::config::actions
   * rsyslog::config::inputs
   * rsyslog::config::custom
+  * rsyslog::config::legacy
   ```
 
   Each of the above classes accepts either an Array or Hash as its input. There

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -16,6 +16,7 @@ rsyslog::feature_packages: []
 
 ## Default object type priorities (can be overridden)
 rsyslog::module_load_priority: 10
+rsyslog::legacy_config_priority: 11
 rsyslog::input_priority: 15
 rsyslog::global_config_priority: 20
 rsyslog::main_queue_priority: 25

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -1,5 +1,6 @@
 class rsyslog::client (
   Optional[Hash]  $global_config   = {},
+  Optional[Hash]  $legacy_config   = {},
   Optional[Hash]  $actions         = {},
   Optional[Hash]  $inputs          = {},
   Optional[Hash]  $custom_config   = {},
@@ -10,6 +11,7 @@ class rsyslog::client (
 
   class { 'rsyslog::config':
     global_config => $global_config,
+    legacy_config => $legacy_config,
     actions       => $actions,
     inputs        => $inputs,
     custom_config => $custom_config,

--- a/manifests/component/legacy_config.pp
+++ b/manifests/component/legacy_config.pp
@@ -2,7 +2,7 @@ define rsyslog::component::legacy_config (
   Integer           $priority,
   String            $target,
   String            $value,
-  Optional[String]  $key,
+  Optional[String]  $key = 'legacy_key',
   Optional[String]  $type = 'sysklogd',
   Optional[String]  $format = '<%= $content %>'
 ) {

--- a/manifests/component/legacy_config.pp
+++ b/manifests/component/legacy_config.pp
@@ -1,0 +1,25 @@
+define rsyslog::component::legacy_config (
+  Integer           $priority,
+  String            $target,
+  String            $value,
+  Optional[String]  $key,
+  Optional[String]  $type = 'sysklogd',
+  Optional[String]  $format = '<%= $content %>'
+) {
+
+  include rsyslog
+
+  $content = epp('rsyslog/legacy_config.epp', {
+        'config_item' => $name,
+        'type'        => $type,
+        'key'         => $key,
+        'value'       => $value,
+  })
+
+  concat::fragment {"rsyslog::component::legacy_config::${name}":
+    target  => "${::rsyslog::confdir}/${target}",
+    content => inline_epp($format),
+    order   => $priority,
+  }
+
+}

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,5 +1,6 @@
 class rsyslog::config (
   Optional[Hash] $global_config = {},
+  Optional[Hash] $legacy_config = {},
   Optional[Hash] $templates = {},
   Optional[Hash] $actions = {},
   Optional[Hash] $inputs = {},
@@ -15,6 +16,7 @@ class rsyslog::config (
 
   include rsyslog::config::modules
   include rsyslog::config::global
+  include rsyslog::config::legacy
   include rsyslog::config::main_queue
   include rsyslog::config::templates
   include rsyslog::config::actions

--- a/manifests/config/legacy.pp
+++ b/manifests/config/legacy.pp
@@ -1,0 +1,10 @@
+class rsyslog::config::legacy {
+  $::rsyslog::config::legacy_config.each |$name, $config| {
+    rsyslog::component::legacy_config { $name:
+      * => {
+        'priority' => $::rsyslog::legacy_config_priority,
+        'target'   => $::rsyslog::target_file,
+      } + $config,
+    }
+  }
+}

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -57,6 +57,7 @@ class rsyslog (
   Boolean $manage_confdir,
   Boolean $purge_config_files,
   Integer $global_config_priority,
+  Integer $legacy_config_priority,
   Integer $template_priority,
   Integer $action_priority,
   Integer $input_priority,

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -1,5 +1,6 @@
 class rsyslog::server (
   Optional[Hash]  $global_config   = {},
+  Optional[Hash]  $legacy_config   = {},
   Optional[Hash]  $templates       = {},
   Optional[Hash]  $actions         = {},
   Optional[Hash]  $inputs          = {},
@@ -13,6 +14,7 @@ class rsyslog::server (
 
   class { 'rsyslog::config':
     global_config   => $global_config,
+    legacy_config   => $legacy_config,
     templates       => $templates,
     actions         => $actions,
     inputs          => $inputs,

--- a/templates/legacy_config.epp
+++ b/templates/legacy_config.epp
@@ -6,7 +6,7 @@
 | -%>
 <% if $type == 'sysklogd' { -%>
 # <%= $config_item %>
-<%= $key %>                 <%= $value %>
+<%= $key %>     <%= $value %>
 
 <% } else { -%>
 # <%= $config_item %>

--- a/templates/legacy_config.epp
+++ b/templates/legacy_config.epp
@@ -1,0 +1,15 @@
+<%- |
+  String $config_item,
+  String $value,
+  Optional[String] $key,
+  Optional[String] $type
+| -%>
+<% if $type == 'sysklogd' { -%>
+# <%= $config_item %>
+<%= $key %>                 <%= $value %>
+
+<% } else { -%>
+# <%= $config_item %>
+<%= $value %>
+
+<% } -%>


### PR DESCRIPTION
The documentation needs to be updated pending your approval. I've tested it with the below data. If you have any suggestions for improvement, I'm happy to implement it. thanks.

This time I will do the documentation as a separate pull request :)

```
rsyslog::client::legacy_config:
  auth_priv_rule:
    key: "auth,authpriv.*"
    value: "/var/log/auth.log"
  auth_none_rule:
    key: "*.*;auth,authpriv.none"
    value: "/var/log/syslog"
  syslog_all_rule:
    key: "syslog.*"
    value: "/var/log/rsyslog.log"
  kernel_all_rule:
    key: "kern.*"
    value: "/var/log/kern.log"
  mail_all_rule:
    key: "mail.*"
    value: "/var/log/mail.log"
  mail_error_rule:
    key: "mail.err"
    value: "/var/log/mail.err"
  news_critical_rule:
    key: "news.crit"
    value: "/var/log/news/news.crit"
  news_error_rule:
    key: "news.err"
    value: "/var/log/news/news.err"
  news_notice_rule:
    key: "news.notice"
    value: "/var/log/news/news.notice"
  emergency_rule:
    key: "*.emerg"
    value: ":omusrmsg:*"
  testing_legacy_rule:
    value: "*.* >dbhost,dbname,dbuser,dbpassword;dbtemplate"
    type: "legacy"
  testing_legacy_remote_logserver:
    value: "*.* @@logmonster.cloudfront.net:1514"
    type: "legacy"
```