### PR TITLE
Feature/module hash

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -15,13 +15,13 @@ rsyslog::service_enabled: true
 rsyslog::feature_packages: []
 
 ## Default object type priorities (can be overridden)
-rsyslog::module_load_priority: 10
-rsyslog::legacy_config_priority: 11
-rsyslog::input_priority: 15
-rsyslog::global_config_priority: 20
-rsyslog::main_queue_priority: 25
-rsyslog::template_priority: 30
-rsyslog::action_priority: 40
+rsyslog::global_config_priority: 10
+rsyslog::module_load_priority: 20
+rsyslog::input_priority: 30
+rsyslog::main_queue_priority: 40
+rsyslog::template_priority: 50
+rsyslog::action_priority: 60
+rsyslog::legacy_config_priority: 70
 rsyslog::custom_priority: 90
 rsyslog::target_file: 50_rsyslog.conf
 

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -4,7 +4,7 @@ class rsyslog::client (
   Optional[Hash]  $actions         = {},
   Optional[Hash]  $inputs          = {},
   Optional[Hash]  $custom_config   = {},
-  Optional[Array] $modules         = [],
+  Optional[Hash]  $modules         = {},
 ) {
 
   include rsyslog

--- a/manifests/component/module.pp
+++ b/manifests/component/module.pp
@@ -1,0 +1,23 @@
+define rsyslog::component::module (
+  Integer           $priority,
+  String            $target,
+  Optional[Hash]    $config = {},
+  Optional[String]  $type = 'external',
+  Optional[String]  $format = '<%= $content %>'
+) {
+
+  include rsyslog
+
+  $content = epp('rsyslog/modules.epp', {
+        'config_item' => $name,
+        'type'        => $type,
+        'config'      => $config,
+  })
+
+  concat::fragment {"rsyslog::component::module::${name}":
+    target  => "${::rsyslog::confdir}/${target}",
+    content => inline_epp($format),
+    order   => $priority,
+  }
+}
+

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -6,7 +6,7 @@ class rsyslog::config (
   Optional[Hash] $inputs = {},
   Optional[Hash] $custom_config = {},
   Optional[Hash] $main_queue_opts = {},
-  Optional[Array] $modules = [],
+  Optional[Hash] $modules = {},
 ) {
 
   concat { "${::rsyslog::confdir}/${::rsyslog::target_file}":

--- a/manifests/config/modules.pp
+++ b/manifests/config/modules.pp
@@ -1,15 +1,10 @@
-class rsyslog::config::modules {
-
-  $modules = $::rsyslog::config::modules
-  concat::fragment { 'rsyslog::config::modules':
-    target  => "${::rsyslog::confdir}/${::rsyslog::target_file}",
-    order   => $::rsyslog::module_load_priority,
-    content => epp('rsyslog/modules.epp',
-      {
-        'modules' => $modules
-      }
-    ),
+class rsyslog::config::modules{
+  $::rsyslog::config::modules.each|$name, $config| {
+    rsyslog::component::module { $name:
+      * => {
+        'priority' => $::rsyslog::module_load_priority,
+        'target'   => $::rsyslog::target_file,
+      } + $config,
+    }
   }
 }
-
-

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -6,7 +6,7 @@ class rsyslog::server (
   Optional[Hash]  $inputs          = {},
   Optional[Hash]  $custom_config   = {},
   Optional[Hash]  $main_queue_opts = {},
-  Optional[Array] $modules         = [],
+  Optional[Hash]  $modules         = {},
 ) {
 
   include rsyslog

--- a/templates/modules.epp
+++ b/templates/modules.epp
@@ -23,5 +23,3 @@ module ( load="builtin:<%= $config_item -%>"
      <% } %>
 )
 <%}-%>
-
-

--- a/templates/modules.epp
+++ b/templates/modules.epp
@@ -1,6 +1,27 @@
 <%- |
-  Array $modules
+  String $config_item,
+  String $type,
+  Optional[Hash] $config
 | -%>
-<% $modules.each | $module | { -%>
-module(load="<%= $module %>")
+<% if $type == 'external' and empty($config) == true  { -%>
+module ( load="<%=$config_item %>" )
 <% } -%>
+<% elsif $type == 'external' and empty($config) == false { -%>
+module ( load="<%= $config_item -%>" 
+     <% $config.each |$key, $value| {-%>
+     <%= $key %>="<%= $value -%>"
+     <% } %>
+)
+<% } -%>
+<% elsif $type == 'builtin' and empty($config) == true  { -%>
+module ( load="builtin:<%= $config_item %>" )
+<% } -%>
+<% elsif $type == 'builtin' and empty($config) == false { -%>
+module ( load="builtin:<%= $config_item -%>" 
+     <% $config.each |$key, $value| {-%> 
+     <%= $key %>="<%= $value -%>"
+     <% } %>
+)
+<%}-%>
+
+


### PR DESCRIPTION
Provides option support for module configuration and tweaked module priorities for optimal configuration

```
rsyslog::server::modules:
  imuxsock: {}
  imklog: {}
  omelasticsearch: {}
  imtcp: {}
  imudp:
    config:
      threads: "2"
      TimeRequery: "8"
      batchSize: "128"
  omusrmsg:
    type: "builtin"
  omfile:
    type: "builtin"
    config:
      fileOwner: "syslog"
      fileGroup: "adm"
      dirGroup: "adm"
      fileCreateMode: "0640"
      dirCreateMode: "0755" 
  impstats:
    type: "external"
    config:
      interval: "60"
      severity: "7"
      log.syslog: "off"
      log.file: "/var/log/rsyslog/logs/stats/stats.log"
      Ruleset: "remote"
```
will produce this output

```
module ( load="imtcp" )
module ( load="omelasticsearch" )
module ( load="builtin:omusrmsg" )
module ( load="imklog" )
module ( load="impstats" 
          interval="60"
          severity="7"
          log.syslog="off"
          log.file="/var/log/rsyslog/logs/stats/stats.log"
          Ruleset="remote"
     
)
module ( load="imuxsock" )
module ( load="imudp" 
          threads="2"
          TimeRequery="8"
          batchSize="128"
     
)
module ( load="builtin:omfile" 
          fileOwner="syslog"
          fileGroup="adm"
          dirGroup="adm"
          fileCreateMode="0640"
          dirCreateMode="0755"
     
)
```