### PR TITLE
fixes to rspec

### DIFF
--- a/spec/classes/config/main_queue_spec.rb
+++ b/spec/classes/config/main_queue_spec.rb
@@ -25,8 +25,8 @@ describe 'rsyslog::server', :include_rsyslog => true do
       it do
         is_expected.to contain_concat__fragment('rsyslog::config::main_queue').with_content(
           /(?x)\s*main_queue\s*\(\n
-          \s+queue.maxdiskspace="1000G"\s*\n
-          \s+queue.dequeuebatchsize="1000"\s*\n
+          \s*queue.maxdiskspace="1000G"\s*\n
+          \s*queue.dequeuebatchsize="1000"\s*\n
           \s*\)\s*/)
       end
     end

--- a/spec/classes/config/main_queue_spec.rb
+++ b/spec/classes/config/main_queue_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
 
-describe 'rsyslog::server' do
+
+describe 'rsyslog::server', :include_rsyslog => true do
   let(:title) { 'main_queue' }
 
   let (:params) {{

--- a/spec/classes/config/modules_spec.rb
+++ b/spec/classes/config/modules_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe 'rsyslog::server' do
+describe 'rsyslog::server', :include_rsyslog => true do
   let (:params) {{
     :modules => { "imuxsock"=>{},}
   }}

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-describe 'rsyslog' do
+describe 'rsyslog', :include_rsyslog => true do
 
   context 'with defaults for all parameters' do
     it { should contain_class('rsyslog') }

--- a/spec/defines/component/action_spec.rb
+++ b/spec/defines/component/action_spec.rb
@@ -19,8 +19,8 @@ describe 'rsyslog::component::action', :include_rsyslog => true do
       is_expected.to contain_concat__fragment('rsyslog::component::action::myaction').with_content(
         /(?x)# myaction\n
         \s*action\(type="omelasticsearch"\s*\n
-        \s+queue\.type="linkedlist"\s*\n
-        \s+queue\.spoolDirectory="\/var\/log\/rsyslog\/queue"\s*\n
+        \s*queue\.type="linkedlist"\s*\n
+        \s*queue\.spoolDirectory="\/var\/log\/rsyslog\/queue"\s*\n
         \s*\)\s*/)
     end
   end
@@ -39,7 +39,7 @@ describe 'rsyslog::component::action', :include_rsyslog => true do
     it do
       is_expected.to contain_concat__fragment('rsyslog::component::action::myaction').with_content(
         /(?x)# myaction\n
-        ^kern\.\*\s*action\(type="omfile"\s*dynaFile="remoteKern"\s*\)\s*/)
+        ^kern\.\*\s*action\(type="omfile"\s+dynaFile="remoteKern"\s*\)\s*/)
     end
   end
 
@@ -70,19 +70,19 @@ describe 'rsyslog::component::action', :include_rsyslog => true do
         /(?x)# myaction\n
         ^\*\.\*
         \s*action\(type="omelasticsearch"\s*\n
-        \s+template="plain-syslog"\s*\n
-        \s+searchIndex="logstash-index"\s*\n
-        \s+queue.type="linkedlist"\s*\n
-        \s+queue.spoolDirectory="\/var\/log\/rsyslog\/queue"\s*\n
-        \s+queue.filename="dbq"\s*\n
-        \s+queue.maxdiskspace="100g"\s*\n
-        \s+queue.maxfilesize="100m"\s*\n
-        \s+queue.SaveOnShutdown="on"\s*\n
-        \s+server="logstash.domain.local"\s*\n
-        \s+action.resumeretrycount="-1"\s*\n
-        \s+bulkmode="on"\s*\n
-        \s+dynSearchIndex="on"\s*\n
-        \s+\)\s*$\n/)
+        \s*template="plain-syslog"\s*\n
+        \s*searchIndex="logstash-index"\s*\n
+        \s*queue.type="linkedlist"\s*\n
+        \s*queue.spoolDirectory="\/var\/log\/rsyslog\/queue"\s*\n
+        \s*queue.filename="dbq"\s*\n
+        \s*queue.maxdiskspace="100g"\s*\n
+        \s*queue.maxfilesize="100m"\s*\n
+        \s*queue.SaveOnShutdown="on"\s*\n
+        \s*server="logstash.domain.local"\s*\n
+        \s*action.resumeretrycount="-1"\s*\n
+        \s*bulkmode="on"\s*\n
+        \s*dynSearchIndex="on"\s*\n
+        \s*\)\s*$\n/)
     end
   end
 

--- a/spec/defines/component/action_spec.rb
+++ b/spec/defines/component/action_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'yaml'
 
-describe 'rsyslog::component::action' do
+describe 'rsyslog::component::action', :include_rsyslog => true do
   let(:title) { 'myaction' }
 
   context 'default action without facility' do

--- a/spec/defines/component/global_config_spec.rb
+++ b/spec/defines/component/global_config_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'yaml'
 
-describe 'rsyslog::component::global_config' do
+describe 'rsyslog::component::global_config', :include_rsyslog => true do
   let(:title) { 'configoption' }
 
   context 'when configuring a legacy type value' do

--- a/spec/defines/component/input_spec.rb
+++ b/spec/defines/component/input_spec.rb
@@ -18,7 +18,7 @@ describe 'rsyslog::component::input', :include_rsyslog => true do
       is_expected.to contain_concat__fragment('rsyslog::component::input::myinput').with_content(
         /(?x)# myinput\n
         \s*input\(type="imudp"\s*\n
-        \s+port="514"\s*\n
+        \s*port="514"\s*\n
         \s*\)\s*/)
     end
   end

--- a/spec/defines/component/input_spec.rb
+++ b/spec/defines/component/input_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'yaml'
 
-describe 'rsyslog::component::input' do
+describe 'rsyslog::component::input', :include_rsyslog => true do
   let(:title) { 'myinput' }
 
   context 'string input' do

--- a/spec/defines/component/legacy_config_spec.rb
+++ b/spec/defines/component/legacy_config_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'yaml'
 
-describe 'rsyslog::component::legacy_config' do
+describe 'rsyslog::component::legacy_config', :include_rsyslog => true do
   let(:title) { 'mylegacy_rules' }
 
   context 'key/value legacy rules' do

--- a/spec/defines/component/module_spec.rb
+++ b/spec/defines/component/module_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'yaml'
 
-describe 'rsyslog::component::module' do
+describe 'rsyslog::component::module', :include_rsyslog => true do
   let(:title) { 'impstats' }
 
   context 'string action' do

--- a/spec/defines/component/module_spec.rb
+++ b/spec/defines/component/module_spec.rb
@@ -21,12 +21,12 @@ describe 'rsyslog::component::module', :include_rsyslog => true do
     it do
       is_expected.to contain_concat__fragment('rsyslog::component::module::impstats').with_content(
         /(?x)module\s*\(\s*load="impstats"\s*\n
-        \s+interval="60"\n
-        \s+severity="7"\n
-        \s+log.syslog="off"\n
-        \s+log.file="\/var\/log\/rsyslog\/logs\/stats\/stats.log"\n
-        \s+Ruleset="remote"\n
-        \s+\n
+        \s*interval="60"\n
+        \s*severity="7"\n
+        \s*log.syslog="off"\n
+        \s*log.file="\/var\/log\/rsyslog\/logs\/stats\/stats.log"\n
+        \s*Ruleset="remote"\n
+        \s*\n
         \)\n$/)
     end
 

--- a/spec/defines/component/template_spec.rb
+++ b/spec/defines/component/template_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'yaml'
 
-describe 'rsyslog::component::template' do
+describe 'rsyslog::component::template', :include_rsyslog => true do
   let(:title) { 'mytpl' }
 
   context 'string template' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,1 +1,47 @@
 require 'puppetlabs_spec_helper/module_spec_helper'
+require 'spec_helper'
+
+RSpec.shared_context "rsyslog_class", :shared_context => :metadata do
+
+
+  # If we're testing on Puppet >=4.3 then data in modules will make
+  # sure that the defaults are set for the rsyslog class, otherwise
+  # we need to specifically declare it.
+  #
+  unless ENV['PUPPET_VERSION'].to_s >= '4.3'
+    let(:pre_condition) { 
+      <<-EOT
+      class { 'rsyslog':
+        confdir =>  '/etc/rsyslog.d',
+        package_name =>  'rsyslog',
+        package_version =>  'installed',
+        manage_package =>  true,
+        manage_confdir =>  true,
+        purge_config_files =>  true,
+        override_default_config =>  true,
+        config_file =>  '/etc/rsyslog.conf',
+        service_name =>  'rsyslog',
+        service_status =>  'running',
+        service_enabled =>  true,
+        feature_packages  => [],
+        global_config_priority =>  10,
+        module_load_priority =>  20,
+        input_priority =>  30,
+        main_queue_priority =>  40,
+        template_priority =>  50,
+        action_priority =>  60,
+        legacy_config_priority =>  70,
+        custom_priority =>  90,
+        target_file =>  '50_rsyslog.conf',
+      }
+      EOT
+    }
+  end
+end
+
+RSpec.configure do |rspec|
+  rspec.include_context "rsyslog_class", :include_rsyslog => true
+end
+
+
+

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,14 +1,10 @@
 require 'puppetlabs_spec_helper/module_spec_helper'
 require 'spec_helper'
+require 'puppet'
 
 RSpec.shared_context "rsyslog_class", :shared_context => :metadata do
 
 
-  # If we're testing on Puppet >=4.3 then data in modules will make
-  # sure that the defaults are set for the rsyslog class, otherwise
-  # we need to specifically declare it.
-  #
-  unless ENV['PUPPET_VERSION'].to_s >= '4.3'
     let(:pre_condition) { 
       <<-EOT
       class { 'rsyslog':
@@ -36,7 +32,6 @@ RSpec.shared_context "rsyslog_class", :shared_context => :metadata do
       }
       EOT
     }
-  end
 end
 
 RSpec.configure do |rspec|

--- a/templates/global_config.epp
+++ b/templates/global_config.epp
@@ -1,7 +1,7 @@
 <%- |
+  String $type,
   Optional[String] $value="dummy",
   Optional[String] $config_item="dummy",
-  String $type,
   Optional[Hash]  $config={},
 | -%>
 <% if $type == 'legacy' { -%>


### PR DESCRIPTION

Since fixing the previous problem where a misaligment of the use of PUPPET_VERSION and PUPPET_GEM_VERSION meant the tests werent actually getting run against the right puppet versions.  That fix exposed the issue that data in modules was released in 4.3.0 and the rspec tests were requiring that rsyslog defaults get looked up magically.  This PR fixes the tests for puppet < 4.3 by explicitly declaring the class.
