### PR TITLE
Create `external_service` parameter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_install:
   - gem --version
   - bundle -v
 
-script: 'SPE_OPTS="--format documentation" bundle exec rake default'
+script: 'SPEC_OPTS="--format documentation" bundle exec rake default'
 
 matrix:
   fast_finish: true

--- a/README.md
+++ b/README.md
@@ -101,6 +101,9 @@ State of the service (default: running)
 ##### `rsyslog::service_enabled`
 Whether or not to enable the service (default: true)
 
+##### `rsyslog::external_service`
+Whether or not to use an external service, be it managed by another module (such as a container service managed by `garethr-docker`) or unmanaged. MUST be used with `rsyslog::service_name` and cannot be used with `rsyslog::manage_service`. (default: false)
+
 ### Rsyslog Configuration Directives
 
 ##### Config file

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -11,6 +11,7 @@ rsyslog::manage_service: true
 rsyslog::service_name: rsyslog
 rsyslog::service_status: running
 rsyslog::service_enabled: true
+rsyslog::external_service: false
 
 ## This can be an array of extra "feature" packages to install for rsyslog
 rsyslog::feature_packages: []

--- a/manifests/generate_concat.pp
+++ b/manifests/generate_concat.pp
@@ -9,6 +9,13 @@ define rsyslog::generate_concat (
         notify => Service[$::rsyslog::service_name],
       }
     }
+  } elsif $::rsyslog::container_service {
+    if ! defined(Concat["${confdir}/${target}"]) {
+      concat { "${confdir}/${target}":
+        owner  => 'root',
+        notify => Service[$::rsyslog::container_service],
+      }
+    }
   } else {
     if ! defined(Concat["${confdir}/${target}"]) {
       concat { "${confdir}/${target}":

--- a/manifests/generate_concat.pp
+++ b/manifests/generate_concat.pp
@@ -2,18 +2,11 @@ define rsyslog::generate_concat (
   String $confdir,
   String $target,
 ) {
-  if $::rsyslog::manage_service {
+  if $::rsyslog::manage_service or $::rsyslog::external_service {
     if ! defined(Concat["${confdir}/${target}"]) {
       concat { "${confdir}/${target}":
         owner  => 'root',
         notify => Service[$::rsyslog::service_name],
-      }
-    }
-  } elsif $::rsyslog::container_service {
-    if ! defined(Concat["${confdir}/${target}"]) {
-      concat { "${confdir}/${target}":
-        owner  => 'root',
-        notify => Service[$::rsyslog::container_service],
       }
     }
   } else {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -56,6 +56,7 @@ class rsyslog (
   Boolean $manage_package,
   Boolean $manage_confdir,
   Boolean $manage_service,
+  Boolean $external_service,
   Boolean $purge_config_files,
   Integer $global_config_priority,
   Integer $legacy_config_priority,
@@ -68,10 +69,9 @@ class rsyslog (
   Integer $parser_priority,
   Integer $ruleset_priority,
   String  $target_file,
-  Optional[String] $container_service = '',
 ) {
 
-  if $manage_service == true and $container_service != '' {
+  if $manage_service == true and $external_service == true {
     fail('manage_service and container_service cannot be set at the same time!')
   } else {
     class { 'rsyslog::base': }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -68,9 +68,13 @@ class rsyslog (
   Integer $parser_priority,
   Integer $ruleset_priority,
   String  $target_file,
+  Optional[String] $container_service = '',
 ) {
 
-
-  class { 'rsyslog::base': }
+  if $manage_service == true and $container_service != '' {
+    fail('manage_service and container_service cannot be set at the same time!')
+  } else {
+    class { 'rsyslog::base': }
+  }
 
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -72,7 +72,7 @@ class rsyslog (
 ) {
 
   if $manage_service == true and $external_service == true {
-    fail('manage_service and container_service cannot be set at the same time!')
+    fail('manage_service and external_service cannot be set at the same time!')
   } else {
     class { 'rsyslog::base': }
   }


### PR DESCRIPTION
Added an `external_service` boolean parameter for allowing puppet-rsyslog to manage configs/logs shared with other processes that may be managed by other modules.

The most common example would be if someone is using `garethr-docker` to create and manage an rsyslog docker container and `crayfishx-rsyslog` to manage configuration that is shared with the container via a volume. 

In this example, `garethr-docker` generates a service file (upstart, init.d, or systemd) that will stop/start the container as though it were a service. As rsyslog requires a stop/start to read configuration changes, allowing this module to set an externally managed service that `crayfishx-rsyslog` can notify on configuration changes is not only extremely helpful, but almost required.

`external_service` is a boolean that defaults to `false`, _MUST_ be used in conjunction with `service_name`, and _CANNOT_ be used with `manage_service`.